### PR TITLE
Fix cloud.gov in README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Enable PHP extensions in clou.gov
+# Enable PHP extensions in cloud.gov
 
 An example app showing how to enable additional PHP extensions in a cloud.gov app using the standard Cloud Foundry buildpack. Note, more details on this approach can be found [here](https://docs.cloudfoundry.org/buildpacks/php/gsg-php-config.html#options).
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix cloud.gov typo

## Security considerations

none
